### PR TITLE
fix: typings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,10 +6,10 @@ daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - "Type: Security"
+  - 'Type: Security'
 
 # Label to use when marking an issue as stale
-staleLabel: "Status: Abandoned"
+staleLabel: 'Status: Abandoned'
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -7,13 +7,11 @@
  * file that was distributed with this source code.
  */
 
-import { Kleur } from 'kleur'
-
 /**
  * Base class extended by [[Kleur]] and [[Stringify]] classes to have
  * common interface. The API is kept similar to `kleur` package.
  */
-export abstract class Colors implements Kleur {
+export abstract class Colors {
   protected abstract transform(transformation: string): this
   protected abstract transform(transformation: string, text: string | number): string
   protected abstract transform(transformation: string, text?: string | number): this | string


### PR DESCRIPTION
Yop! 

I encountered this error today: #2 

```
node_modules/.pnpm/@poppinss+colors@3.0.2/node_modules/@poppinss/colors/build/src/Base.d.ts:66:5 
- error TS2416: Property 'hidden' in type 'Colors' is not assignable to the same property in base type 'Kleur'.
  Type '{ (): this; (text: string): string; }' is not assignable to type 'Color'.
    Type 'this' is not assignable to type 'string'.

    hidden(): this;
```
This type error is present for all methods defined in the `Colors` class of the `Base.ts` file

---

A simple workaround would be to just set `skipLibCheck` to false. But this is not always desired. Setting `skipLibCheck` would disable type checking on my own written .d.ts files.

So what I propose is just to stop implementing `Kleur` directly. 
As the `Colors` class already implements all the methods of the `Kleur` interface, we won't have any problem. We'll just have to be careful when we update Kleur that we always respect their API. But there is really very little chance that there will be any breaking change on Kleur soon

Here is the type definition of `Kleur`, if needed:

```ts
interface Color {
	(x: string | number): string;
	(): Kleur;
}

interface Kleur {
	// Colors
	black: Color;
	red: Color;
	green: Color;
	yellow: Color;
	blue: Color;
	magenta: Color;
	cyan: Color;
	white: Color;
	gray: Color;
	grey: Color;

	// Backgrounds
	bgBlack: Color;
	bgRed: Color;
	bgGreen: Color;
	bgYellow: Color;
	bgBlue: Color;
	bgMagenta: Color;
	bgCyan: Color;
	bgWhite: Color;

	// Modifiers
	reset: Color;
	bold: Color;
	dim: Color;
	italic: Color;
	underline: Color;
	inverse: Color;
	hidden: Color;
	strikethrough: Color;
}
```

Let me know if you agree with that and I will publish a new version